### PR TITLE
EXPERIMENTAL Pytronics support for i2c and jeelabs lcd plug

### DIFF
--- a/i2c.py
+++ b/i2c.py
@@ -1,0 +1,181 @@
+import os, fcntl
+from ctypes import *
+
+RASCAL_I2C = '/dev/i2c-0'
+
+# smbus_access read or write markers
+I2C_SMBUS_READ = 1
+I2C_SMBUS_WRITE = 0
+
+# SMBus transaction types (size parameter in the above functions) 
+I2C_SMBUS_QUICK = 0
+I2C_SMBUS_BYTE = 1
+I2C_SMBUS_BYTE_DATA = 2 
+I2C_SMBUS_WORD_DATA= 3
+I2C_SMBUS_PROC_CALL = 4
+I2C_SMBUS_BLOCK_DATA = 5
+I2C_SMBUS_I2C_BLOCK_BROKEN = 6
+I2C_SMBUS_BLOCK_PROC_CALL = 7       # SMBus 2.0
+I2C_SMBUS_I2C_BLOCK_DATA = 8
+
+I2C_SLAVE = 0x0703
+I2C_FUNCS = 0x0705
+I2C_SMBUS = 0x0720      # SMBus-level access
+
+I2C_SCAN_BUSY = -2
+I2C_SCAN_NODEV = -1
+I2C_SCAN_SKIPPED = 0
+
+# Data for SMBus Messages 
+I2C_SMBUS_BLOCK_MAX = 32        # As specified in SMBus standard
+I2C_SMBUS_I2C_BLOCK_MAX	= 32    # Not specified but we use same structure
+
+debug = False
+
+class i2c_smbus_data(Union):
+    _fields_ = [('byte', c_ubyte),
+                ('word', c_uint),
+                ('block', c_ubyte * 34)]
+
+class i2c_smbus_ioctl_data(Structure):
+    _fields_ = [('read_write', c_ubyte),
+                ('command', c_ubyte),
+                ('size', c_int),
+                ('data', POINTER(i2c_smbus_data))]
+
+def i2c_smbus_access(file, read_write, command, size, data):
+    try:
+        args = i2c_smbus_ioctl_data(read_write, command, size, data)
+        return fcntl.ioctl(file, I2C_SMBUS, args)
+    except IOError, e:
+        if debug: print '## i2c_smbus_access ##: IOError {0}'.format(e)
+        return -1
+    except IOError, e:
+        return -1
+    except Exception, e:
+        print '## i2c_smbus_access ## {0}'.format(e)
+        return -1
+
+def i2c_smbus_write_quick(file, value):
+    data = i2c_smbus_data(0)
+    return i2c_smbus_access(file, value, 0, I2C_SMBUS_QUICK, pointer(data))
+
+def i2c_smbus_read_byte(file):
+    if debug: print '## i2c_smbus_read_byte ##'
+    data = i2c_smbus_data(0)
+    if (i2c_smbus_access(file, I2C_SMBUS_READ, 0, I2C_SMBUS_BYTE, pointer(data)) == 0):
+        return 0x0FF & data.byte
+    else:
+        return -1
+
+def i2c_smbus_write_byte(file, value):
+    if debug: print '## i2c_smbus_write_byte ##: value 0x{0:00X}'.format(value)
+    data = i2c_smbus_data(0)
+    return i2c_smbus_access(file, I2C_SMBUS_WRITE, value, I2C_SMBUS_BYTE, pointer(data))
+
+def i2c_smbus_read_byte_data(file, daddr):
+    if debug: print '## i2c_smbus_read_byte_data ##: daddr {0}'.format(daddr)
+    data = i2c_smbus_data(0)
+    if (i2c_smbus_access(file, I2C_SMBUS_READ, daddr, I2C_SMBUS_BYTE_DATA, pointer(data)) == 0):
+        return 0x0FF & data.byte
+    else:
+        return -1
+
+def i2c_smbus_write_byte_data(file, daddr, value):
+    if debug: print '## i2c_smbus_write_byte_data ##: daddr {0}, value=0x{1:00X}'.format(daddr, value)
+    data = i2c_smbus_data(0)
+    data.byte = value
+    return i2c_smbus_access(file, I2C_SMBUS_WRITE, daddr, I2C_SMBUS_BYTE_DATA, pointer(data))
+
+def i2c_smbus_read_word_data(file, daddr):
+    if debug: print '## i2c_smbus_read_word_data ##: daddr {0}'.format(daddr)
+    data = i2c_smbus_data(0)
+    if (i2c_smbus_access(file, I2C_SMBUS_READ, daddr, I2C_SMBUS_WORD_DATA, pointer(data)) == 0):
+        return 0x0FFFF & data.word
+    else:
+        return -1
+
+def i2c_smbus_write_word_data(file, daddr, value):
+    if debug: print '## i2c_smbus_write_word_data ##: daddr {0}, value=0x{1:0000X}'.format(daddr, value)
+    data = i2c_smbus_data(0)
+    data.word = value
+    return i2c_smbus_access(file, I2C_SMBUS_WRITE, daddr, I2C_SMBUS_WORD_DATA, pointer(data))
+
+# Main entry points
+def _i2cRead(addr, reg = 0, size = ''):
+    if debug: print '## i2cRead ## addr={0}, reg={1}, size={2}'.format(addr, reg, size)
+    try:
+        file = os.open(RASCAL_I2C, os.O_RDWR)
+        try:
+            fcntl.ioctl(file, I2C_SLAVE, addr)
+            if size.upper() == 'W':
+                data = i2c_smbus_read_word_data(file, reg)
+            elif size.upper() == 'B':
+                data = i2c_smbus_read_byte_data(file, reg)
+            else:
+                data = i2c_smbus_read_byte(file)
+        except Exception, e:
+            if debug: print '## i2cRead ## Can\'t set slave addr {0}'.format(e)
+            data = -1
+        os.close(file)
+    except OSError:
+        if debug: print '## i2cRead ## Can\'t open {0}'.format(RASCAL_I2C)
+        data = -2
+    return data
+
+def _i2cWrite(addr, reg, value, size):
+    if debug: print '## i2cWrite ## addr=0x{0:02x}, reg=0x{1:02x}, value=0x{2:04X}, size={3}'.format(addr, reg, value, size)
+    try:
+        file = os.open(RASCAL_I2C, os.O_RDWR)
+        try:
+            fcntl.ioctl(file, I2C_SLAVE, addr)
+            if size.upper() == 'W':
+                data = i2c_smbus_write_word_data(file, reg, value)
+            elif size.upper() == 'B':
+                data = i2c_smbus_write_byte_data(file, reg, value)
+            else:
+                data = i2c_smbus_write_byte(file, value)
+        except Exception, e:
+            if debug: print '## i2cWrite ## Can\'t set slave addr {0}'.format(e)
+            data = -1
+        os.close(file)
+    except OSError:
+        if debug: print '## i2cWrite ## Can\'t open {0}'.format(RASCAL_I2C)
+        data = -2
+    return data
+
+# Support for scanning i2C bus
+def probe_bus(file, addr):
+    # Set slave address
+    try:
+        fcntl.ioctl(file, I2C_SLAVE, addr)
+        if ((addr >= 0x30 and addr <= 0x37) or (addr >= 0x50 and addr <= 0x5F)):
+            res = i2c_smbus_read_byte(file)
+        else:
+            res = i2c_smbus_write_quick(file, I2C_SMBUS_WRITE)
+        if res < 0:
+            return I2C_SCAN_NODEV
+        else:
+            return addr
+    except Exception, e:
+        return I2C_SCAN_BUSY
+    
+# Address status: 0=out of range, -1=not present, -2=busy, otherwise device address
+def scanBus(first = 0x03, last = 0x77):
+    file = os.open(RASCAL_I2C, os.O_RDWR)
+    scan = {}
+    for i in range(0, 128, 16):
+        row = ()
+        for j in range(0, 16):
+            addr = i + j
+            # Skip unwanted addresses
+            if (addr < first) or (addr > last):
+                row += (I2C_SCAN_SKIPPED,)
+            else:
+                row += (probe_bus(file, addr),)
+        scan[i] = row
+    os.close(file)
+    return scan
+
+
+

--- a/i2c_lcd.py
+++ b/i2c_lcd.py
@@ -1,0 +1,115 @@
+# Support for JeeLabs i2c LCD Plug and HD44780 LCD
+from i2c import _i2cRead, _i2cWrite
+
+# LCD Plug chip address
+LCD = 0x24
+# On power on the MCP23008 IOCON reg defaults to 0x0
+# We disable SEQOP (bit5 = 1) and set INT to open drain (bit2 = 1)
+# Our reset function checks this value to see whether the LCD needs to be initialised
+MCP_IOCON_INIT = 0x24
+
+# MCP23008 registers
+MCP_IODIR = 0x00
+MCP_IOCON = 0x05
+MCP_GPIO = 0x09
+
+# MCP23008 outputs P4-P7 (P0-P3 are data)
+MCP_BACKLIGHT = 0x80
+MCP_ENABLE = 0x40       # Pulse high to write to HD44780
+MCP_OTHER = 0x20
+MCP_REGSEL = 0x10       # 1=LCD data, 0=LCD command
+
+# HD44780 command registers
+LCD_CLR = 0x01
+LCD_HOME = 0x02
+LCD_MODE = 0x04
+LCD_DISPLAY = 0x08
+LCD_SHIFT = 0x10
+LCD_FUNCTION = 0x20
+LCD_CGADDR = 0x40
+LCD_DDADDR = 0x80
+
+
+def _write4bits(rs, value):
+    data = value | MCP_BACKLIGHT | rs
+    _i2cWrite(LCD, MCP_GPIO, data, 'B')
+    _i2cWrite(LCD, MCP_GPIO, data | MCP_ENABLE, 'B')
+    _i2cWrite(LCD, MCP_GPIO, data, 'B')
+
+def writeByte(rs, value):
+    _write4bits(rs, (value >> 4) & 0x0f)
+    _write4bits(rs, value & 0x0f)
+
+def writeCmd(value):
+    writeByte(0, value)
+    
+def writeData(value):
+    writeByte(MCP_REGSEL, value)
+    
+# With gratitude to http://joshuagalloway.com/lcd.html
+# who explains how to do this clearly and concisely
+# See also Hitachi HD4487U specification, page 46
+def init():
+    # Set MCP IO Control register (SREAD disabled, INT to ODR)
+    _i2cWrite(LCD, MCP_IOCON, MCP_IOCON_INIT, 'B')
+    # Set MCP IO Direction register to output (all pins)
+    # A side-effect is to enable backlight on first write to MCP_GPIO
+    _i2cWrite(LCD, MCP_IODIR, 0, 'B')
+
+    # Set to 4-bit mode (Hitachi magic)
+    _write4bits(0, 0x03)
+    _write4bits(0, 0x03)
+    _write4bits(0, 0x03)
+    _write4bits(0, 0x02)
+
+    # 001x xx-- set interface length: 4 bits, 2 lines
+    # bit 4: 8-bit(1)/4-bit(0)
+    # bit 3: 1 line(0)/2 lines(1)
+    # bit 2: font 5x10(1)/5x7(0)
+    writeCmd(LCD_FUNCTION | 0x08)
+
+    # 0000 1xxx enable display/cursor: display off, cursor off, blink off
+    # bit 2: display on
+    # bit 1: display cursor
+    # bit 0: blinking cursor
+    writeCmd(LCD_DISPLAY)
+
+    # 0000 0001 clear display, home cursor
+    writeCmd(LCD_CLR)
+
+    # 0000 01xx set cursor move direction: inc cursor, do not shift data
+    # bit 1: inc(1)/dec(0)
+    # bit 0: shift display
+    writeCmd(LCD_MODE | 0x02)
+    
+    # 0000 1xxx enable display/cursor: display on, cursor off, blink off
+    # bit 2: display on
+    # bit 1: display cursor
+    # bit 0: blinking cursor
+    writeCmd(LCD_DISPLAY | 0x04)
+
+# Backlight is controlled by toggling MCP23008 P7 IO status
+# Set P7 to output (0 = on) or input (1 = off)
+def backlight(state = True):
+    if state:
+        _i2cWrite(LCD, MCP_IODIR, 0, 'B')
+    else:
+        _i2cWrite(LCD, MCP_IODIR, MCP_BACKLIGHT, 'B')
+
+def setCursor(row, col):
+    rowstart = [ 0x00, 0x40, 0x14, 0x54 ]
+    writeCmd(LCD_DDADDR | (rowstart[row] + col))
+    
+def reset(clear = True):
+    # Check if LCD has been initialised
+    if _i2cRead(LCD, MCP_IOCON, 'B') == MCP_IOCON_INIT:
+        if clear:
+            writeCmd(LCD_CLR)
+        else:
+            setCursor(0, 0)
+    else:
+        init()      
+
+def writeString(s):
+    for i in s:
+        writeData(ord(i))

--- a/pytronics.py
+++ b/pytronics.py
@@ -101,12 +101,13 @@ def readPins(pinlist):
             print ('## readPins ## Cannot access pin {0} ({1})'.format(pin, syspin))
     return pins
 
-def i2cRead():
-    pass
+def i2cRead(addr, reg = 0, size = 'B'):
+    from i2c import _i2cRead
+    return _i2cRead(addr, reg, size)
 
-def i2cWrite(val):
-    cmd = 'i2cset -y 0 0x29 ' + str(val)
-    subprocess.Popen([cmd], shell=True)
+def i2cWrite(addr, reg, val, size):
+    from i2c import _i2cWrite
+    return _i2cWrite(addr, reg, val, size)
 
 def serialRead():
     pass


### PR DESCRIPTION
The I2C library is quite large so I chose to reference it from Pytronics rather than include it in its entirety. The support for the JeeLabs LCD Plug is specific to this device. I'm uncertain how Pytronics should be constructed and packaged. On my Rascal, I set up a Pytronics clone and added these two new files, then set up hard links from /usr/lib/python2.6/site-packages. This doesn't seem ideal! Proceed with caution.
