### PR TITLE
Pytronics update for i2c

### DIFF
--- a/pytronics.py
+++ b/pytronics.py
@@ -101,13 +101,13 @@ def readPins(pinlist):
             print ('## readPins ## Cannot access pin {0} ({1})'.format(pin, syspin))
     return pins
 
-def i2cRead(addr, reg = 0, size = 'B'):
+def i2cRead(addr, reg = 0, size = 'B', length = 0):
     from i2c import _i2cRead
-    return _i2cRead(addr, reg, size)
+    return _i2cRead(addr, reg, size, length)
 
 def i2cWrite(addr, reg, val = '', size = 'B'):
     from i2c import _i2cWrite
-    return _i2cWrite(addr, reg, val, size)
+    _i2cWrite(addr, reg, val, size)
 
 def serialRead():
     pass


### PR DESCRIPTION
This is quite a big update which removes all the error handling from the i2c functions, letting the errors bubble up, typically to server.py. I also made a change to i2cget and i2cset in server.py to catch the errors and log them. The other change was to add support for I2C block read and write. There are also some minor bug fixes.

The last change was on 31 July 2012. For the past six weeks, I've been running this version continuously across several different I2C devices without any issues.

The changes in Pytronics are just small changes to i2cRead and i2cWrite to support this.
